### PR TITLE
Marquee tool: click-to-deselect, grey-area selection, and Shift 1:1 constraint

### DIFF
--- a/src/ui/canvas_widget.cpp
+++ b/src/ui/canvas_widget.cpp
@@ -310,6 +310,14 @@ QRect normalized_rect(QPoint a, QPoint b) {
   return QRect(a, b).normalized();
 }
 
+QRect rect_from_anchor_and_size(QPoint anchor, int signed_width, int signed_height) {
+  const auto width = std::max(1, std::abs(signed_width));
+  const auto height = std::max(1, std::abs(signed_height));
+  const auto x = signed_width < 0 ? anchor.x() - width : anchor.x();
+  const auto y = signed_height < 0 ? anchor.y() - height : anchor.y();
+  return QRect(x, y, width, height);
+}
+
 double point_distance(QPointF a, QPointF b) {
   return std::hypot(a.x() - b.x(), a.y() - b.y());
 }
@@ -702,6 +710,11 @@ Layer* topmost_text_layer_at_recursive(std::vector<Layer>& layers, QPoint docume
 QPoint clamped_document_point(const Document& document, QPoint point) {
   return QPoint(std::clamp(point.x(), 0, std::max(0, document.width() - 1)),
                 std::clamp(point.y(), 0, std::max(0, document.height() - 1)));
+}
+
+QPoint edge_clamped_document_point(const Document& document, QPoint point) {
+  return QPoint(std::clamp(point.x(), 0, std::max(0, document.width())),
+                std::clamp(point.y(), 0, std::max(0, document.height())));
 }
 
 std::uint8_t mask_value_from_color(QColor color) {
@@ -3730,21 +3743,26 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     clear_guide_selection();
   }
   if (!document_contains(document_point)) {
-    // The Move tool's transform resize and rotate handles can sit outside the
-    // document bounds (for example after scaling a layer larger than the
-    // canvas). Let a press that lands on one of those handles fall through to
-    // the transform-handle hit-test below instead of discarding it here;
-    // otherwise the handles can be hovered but never grabbed once they extend
-    // past the canvas edge. The interior Move hit still falls back to the
-    // normal out-of-bounds behaviour.
-    const auto off_canvas_transform_rect = move_transform_controls_rect();
-    const auto off_canvas_handle =
-        off_canvas_transform_rect.has_value()
-            ? transform_handle_at(event->pos(), *off_canvas_transform_rect, 0.0)
-            : TransformHandle::None;
-    if (off_canvas_handle == TransformHandle::None || off_canvas_handle == TransformHandle::Move) {
-      set_move_transform_controls_layer(std::nullopt);
-      return;
+    // Marquee presses may begin in the grey area; let them through to the marquee
+    // handler. Other tools discard an out-of-bounds press.
+    const bool marquee_tool = tool_ == CanvasTool::Marquee || tool_ == CanvasTool::EllipticalMarquee;
+    if (!marquee_tool) {
+      // The Move tool's transform resize and rotate handles can sit outside the
+      // document bounds (for example after scaling a layer larger than the
+      // canvas). Let a press that lands on one of those handles fall through to
+      // the transform-handle hit-test below instead of discarding it here;
+      // otherwise the handles can be hovered but never grabbed once they extend
+      // past the canvas edge. The interior Move hit still falls back to the
+      // normal out-of-bounds behaviour.
+      const auto off_canvas_transform_rect = move_transform_controls_rect();
+      const auto off_canvas_handle =
+          off_canvas_transform_rect.has_value()
+              ? transform_handle_at(event->pos(), *off_canvas_transform_rect, 0.0)
+              : TransformHandle::None;
+      if (off_canvas_handle == TransformHandle::None || off_canvas_handle == TransformHandle::Move) {
+        set_move_transform_controls_layer(std::nullopt);
+        return;
+      }
     }
   }
 
@@ -3943,6 +3961,12 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     selecting_ = true;
     spacebar_repositioning_drag_rect_ = false;
     selection_edges_visible_ = true;
+    selection_press_widget_position_ = event->pos();
+    // Shift adds to an existing selection, but constrains to a square when there
+    // is nothing to add to.
+    selection_shift_at_press_ = (event->modifiers() & Qt::ShiftModifier) != 0 && !selection_.isEmpty();
+    selection_shift_released_since_press_ = false;
+    selection_square_constrained_ = false;
     selection_start_ = snapped_point;
     selection_current_ = snapped_point;
     selection_before_edit_ = selection_;
@@ -4291,6 +4315,7 @@ void CanvasWidget::mouseMoveEvent(QMouseEvent* event) {
       selection_start_ = spacebar_reposition_start_selection_start_ + delta;
       selection_current_ = spacebar_reposition_start_selection_current_ + delta;
     } else {
+      update_selection_square_constraint(event->modifiers());
       selection_current_ = snapped_marquee_current_point(selection_start_, document_point);
     }
     combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
@@ -4610,6 +4635,24 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
   if (selecting_) {
     selecting_ = false;
     const auto document_point = document_position(event->pos());
+    const auto widget_delta = event->pos() - selection_press_widget_position_;
+    const bool was_click = !spacebar_repositioning_drag_rect_ &&
+                           marquee_style_ != MarqueeStyle::FixedSize &&
+                           widget_delta.manhattanLength() < QApplication::startDragDistance();
+    if (was_click) {
+      // A plain click (no drag) deselects in Replace mode; add/subtract are no-ops.
+      restore_selection_before_edit();
+      if (selection_operation_ == SelectionMode::Replace) {
+        clear_selection();
+      }
+      selection_before_edit_ = QRegion();
+      selection_display_region_before_edit_ = QRegion();
+      selection_mask_before_edit_bounds_ = {};
+      selection_mask_before_edit_alpha_ = QImage();
+      emit_info_for_widget_position(event->pos());
+      update();
+      return;
+    }
     if (spacebar_repositioning_drag_rect_) {
       const auto raw_delta = document_point - spacebar_reposition_origin_document_position_;
       const auto delta = snapped_rect_delta(
@@ -4620,6 +4663,7 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
       selection_current_ = spacebar_reposition_start_selection_current_ + delta;
       spacebar_repositioning_drag_rect_ = false;
     } else {
+      update_selection_square_constraint(event->modifiers());
       selection_current_ = snapped_marquee_current_point(selection_start_, document_point);
     }
     if (selection_feather_radius_ > 0) {
@@ -4830,6 +4874,16 @@ void CanvasWidget::keyPressEvent(QKeyEvent* event) {
     return;
   }
 
+  // Shift toggled mid-drag arrives as a key event, not a mouse move; update the
+  // constraint here so a stationary cursor still responds.
+  if (selecting_ && !spacebar_repositioning_drag_rect_ && event->key() == Qt::Key_Shift &&
+      !event->isAutoRepeat()) {
+    update_selection_square_constraint(event->modifiers() | Qt::ShiftModifier);
+    refresh_active_marquee_selection();
+    event->accept();
+    return;
+  }
+
   if (transforming_layer_) {
     if (event->key() == Qt::Key_Escape) {
       cancel_free_transform();
@@ -4924,6 +4978,13 @@ void CanvasWidget::keyReleaseEvent(QKeyEvent* event) {
     spacebar_repositioning_drag_rect_ = false;
     spacebar_panning_ = false;
     set_tool(tool_);
+    event->accept();
+    return;
+  }
+  if (selecting_ && !spacebar_repositioning_drag_rect_ && event->key() == Qt::Key_Shift &&
+      !event->isAutoRepeat()) {
+    update_selection_square_constraint(event->modifiers() & ~Qt::ShiftModifier);
+    refresh_active_marquee_selection();
     event->accept();
     return;
   }
@@ -8695,8 +8756,25 @@ QRect CanvasWidget::marquee_selection_rect(QPoint anchor, QPoint current) const 
     const auto signed_width = delta.x() < 0 ? -width : width;
     const auto signed_height = delta.y() < 0 ? -height : height;
     rect = QRect(anchor, anchor + QPoint(signed_width, signed_height)).normalized();
+  } else if (selection_square_constrained_) {
+    // 1:1 square (circle for the ellipse), sized to the smaller drag axis and
+    // anchored at the canvas edge so a drag begun in the grey area starts there.
+    const auto square_anchor = document_ != nullptr ? edge_clamped_document_point(*document_, anchor) : anchor;
+    const auto delta = current - square_anchor;
+    const auto side = std::max(1, std::min(std::abs(delta.x()), std::abs(delta.y())));
+    const auto signed_width = delta.x() < 0 ? -side : side;
+    const auto signed_height = delta.y() < 0 ? -side : side;
+    rect = rect_from_anchor_and_size(square_anchor, signed_width, signed_height);
   } else {
     rect = normalized_rect(anchor, current);
+  }
+  // Keep at least 1px per axis: QRect::normalized() leaves a 0-size rect when the
+  // cursor lands exactly 1px before the anchor, blanking the selection mid-drag.
+  if (rect.width() < 1) {
+    rect.setWidth(1);
+  }
+  if (rect.height() < 1) {
+    rect.setHeight(1);
   }
   return rect;
 }
@@ -8829,6 +8907,26 @@ void CanvasWidget::set_selection_from_mask(QRegion selection, QRect mask_bounds,
   }
   selection_mask_alpha_ = std::move(mask_alpha);
   refresh_info_display();
+}
+
+void CanvasWidget::update_selection_square_constraint(Qt::KeyboardModifiers modifiers) {
+  const bool shift_now = (modifiers & Qt::ShiftModifier) != 0;
+  if (!shift_now) {
+    selection_shift_released_since_press_ = true;
+  }
+  // Shift after the drag starts constrains; Shift held from press is "add", so it
+  // only constrains after being released and pressed again.
+  selection_square_constrained_ =
+      shift_now && (!selection_shift_at_press_ || selection_shift_released_since_press_);
+}
+
+void CanvasWidget::refresh_active_marquee_selection() {
+  if (!selecting_ || spacebar_repositioning_drag_rect_) {
+    return;
+  }
+  combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+  emit_info_for_widget_position(last_mouse_position_);
+  update();
 }
 
 void CanvasWidget::restore_selection_before_edit() {

--- a/src/ui/canvas_widget.hpp
+++ b/src/ui/canvas_widget.hpp
@@ -547,6 +547,8 @@ private:
   void set_selection_from_region(QRegion selection);
   void set_selection_from_mask(QRegion selection, QRect mask_bounds, QImage mask_alpha);
   void restore_selection_before_edit();
+  void update_selection_square_constraint(Qt::KeyboardModifiers modifiers);
+  void refresh_active_marquee_selection();
   [[nodiscard]] SelectionMode selection_operation(Qt::KeyboardModifiers modifiers) const noexcept;
   [[nodiscard]] QRegion combine_selection(const QRegion& candidate) const;
   void combine_selection_from_region(const QRegion& candidate);
@@ -632,6 +634,10 @@ private:
   QPoint move_start_{};
   QPoint selection_start_{};
   QPoint selection_current_{};
+  QPoint selection_press_widget_position_{};
+  bool selection_shift_at_press_{false};
+  bool selection_shift_released_since_press_{false};
+  bool selection_square_constrained_{false};
   CanvasTool tool_{CanvasTool::Brush};
   LayerEditTarget layer_edit_target_{LayerEditTarget::Content};
   MaskDisplayMode mask_display_mode_{MaskDisplayMode::None};

--- a/tests/ui_visual_tests.cpp
+++ b/tests/ui_visual_tests.cpp
@@ -9606,6 +9606,159 @@ void ui_marquee_selection_modifiers_work() {
   CHECK(!canvas->has_selection());
 }
 
+void ui_marquee_click_outside_canvas_deselects() {
+  patchy::ui::MainWindow window;
+  show_window(window);
+  auto* canvas = require_canvas(window);
+  canvas->set_tool(patchy::ui::CanvasTool::Marquee);
+
+  // A widget point mapping to a document coordinate outside the canvas.
+  const auto grey = canvas->widget_position_for_document_point(QPoint(-40, -40));
+  CHECK(canvas->rect().contains(grey));
+
+  drag(*canvas, canvas->widget_position_for_document_point(QPoint(20, 20)),
+       canvas->widget_position_for_document_point(QPoint(80, 80)));
+  CHECK(canvas->has_selection());
+
+  // A plain click in the grey area clears the selection.
+  send_mouse(*canvas, QEvent::MouseButtonPress, grey, Qt::LeftButton, Qt::LeftButton);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, grey, Qt::LeftButton, Qt::NoButton);
+  CHECK(!canvas->has_selection());
+
+  // A drag that starts in the grey area still selects, clamped to the canvas.
+  drag(*canvas, grey, canvas->widget_position_for_document_point(QPoint(80, 80)));
+  const auto sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->left() >= 0);
+  CHECK(sel->top() >= 0);
+  CHECK(sel->contains(QPoint(10, 10)));
+}
+
+void ui_marquee_shift_drag_constrains_to_square() {
+  patchy::ui::MainWindow window;
+  show_window(window);
+  auto* canvas = require_canvas(window);
+  canvas->set_tool(patchy::ui::CanvasTool::Marquee);
+
+  const auto start = canvas->widget_position_for_document_point(QPoint(40, 40));
+  const auto wide_end = canvas->widget_position_for_document_point(QPoint(200, 100));  // 160x60 drag
+
+  // No active selection: Shift from the press constrains to a square (side = 60).
+  send_mouse(*canvas, QEvent::MouseButtonPress, start, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, wide_end, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, wide_end, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  auto sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->width() == sel->height());
+  CHECK(sel->width() > 40);
+  CHECK(sel->width() < 120);
+
+  require_action(window, "editDeselectAction")->trigger();
+  QApplication::processEvents();
+
+  // Also constrains when Shift is pressed only after the drag starts.
+  send_mouse(*canvas, QEvent::MouseButtonPress, start, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+  send_mouse(*canvas, QEvent::MouseMove, wide_end, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, wide_end, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->width() == sel->height());
+
+  require_action(window, "editDeselectAction")->trigger();
+  QApplication::processEvents();
+
+  // With an existing selection, Shift at press adds a free shape (not a square):
+  // the far corner, outside a 60x60 square, stays selected.
+  const auto add_start = canvas->widget_position_for_document_point(QPoint(200, 40));
+  const auto add_end = canvas->widget_position_for_document_point(QPoint(360, 100));
+  drag(*canvas, canvas->widget_position_for_document_point(QPoint(40, 40)),
+       canvas->widget_position_for_document_point(QPoint(80, 80)));
+  CHECK(canvas->has_selection());
+  send_mouse(*canvas, QEvent::MouseButtonPress, add_start, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, add_end, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, add_end, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  CHECK(canvas->selected_document_region().contains(QPoint(350, 50)));
+
+  require_action(window, "editDeselectAction")->trigger();
+  QApplication::processEvents();
+
+  // In add-mode, releasing and re-pressing Shift mid-drag constrains the added
+  // shape to a square (via key events, with no intervening mouse move).
+  const auto add_mid = canvas->widget_position_for_document_point(QPoint(280, 70));
+  drag(*canvas, canvas->widget_position_for_document_point(QPoint(40, 40)),
+       canvas->widget_position_for_document_point(QPoint(80, 80)));
+  CHECK(canvas->has_selection());
+  send_mouse(*canvas, QEvent::MouseButtonPress, add_start, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, add_mid, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_key_release(*canvas, Qt::Key_Shift);
+  send_key_press(*canvas, Qt::Key_Shift);
+  send_mouse(*canvas, QEvent::MouseMove, add_end, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, add_end, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  CHECK(canvas->selected_document_region().contains(QPoint(210, 50)));
+  CHECK(!canvas->selected_document_region().contains(QPoint(350, 50)));
+
+  require_action(window, "editDeselectAction")->trigger();
+  QApplication::processEvents();
+  canvas->set_snap_enabled(false);
+  canvas->zoom_to_document_rect(QRect(90, 90, 20, 20));
+
+  // Tiny mixed-axis drags must still resolve to an exact square (2x5 -> 2x2).
+  const auto tiny_start = canvas->widget_position_for_document_point(QPoint(100, 100));
+  const auto tiny_end = canvas->widget_position_for_document_point(QPoint(102, 95));  // 2x5 drag
+  send_mouse(*canvas, QEvent::MouseButtonPress, tiny_start, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, tiny_end, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, tiny_end, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->size() == QSize(2, 2));
+
+  require_action(window, "editDeselectAction")->trigger();
+  QApplication::processEvents();
+
+  // A constrained drag begun in the grey area anchors the square at the edge it
+  // enters, not at the off-canvas press point.
+  const auto document_rect = canvas->active_layer_document_rect();
+  CHECK(document_rect.has_value());
+  const auto right_edge = document_rect->right() + 1;
+  const auto edge_y = document_rect->top() + 100;
+  canvas->zoom_to_document_rect(QRect(right_edge - 30, edge_y - 10, 50, 30));
+
+  const auto outside_start = canvas->widget_position_for_document_point(QPoint(right_edge + 20, edge_y));
+  const auto inside_left = canvas->widget_position_for_document_point(QPoint(right_edge - 20, edge_y));
+  const auto inside_left_down = canvas->widget_position_for_document_point(QPoint(right_edge - 20, edge_y + 2));
+  send_mouse(*canvas, QEvent::MouseButtonPress, outside_start, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, inside_left, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseMove, inside_left_down, Qt::NoButton, Qt::LeftButton, Qt::ShiftModifier);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, inside_left_down, Qt::LeftButton, Qt::NoButton, Qt::ShiftModifier);
+  sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(*sel == QRect(right_edge - 2, edge_y, 2, 2));
+}
+
+void ui_marquee_drag_keeps_minimum_one_pixel() {
+  patchy::ui::MainWindow window;
+  show_window(window);
+  auto* canvas = require_canvas(window);
+  canvas->set_tool(patchy::ui::CanvasTool::Marquee);
+
+  const auto anchor = canvas->widget_position_for_document_point(QPoint(100, 100));
+
+  // Cursor 1px left of the anchor, dragged far vertically: the width axis used to
+  // collapse to 0 (QRect::normalized); the big vertical motion keeps it a drag.
+  drag(*canvas, anchor, canvas->widget_position_for_document_point(QPoint(99, 300)));
+  auto sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->width() >= 1);
+  CHECK(sel->height() >= 1);
+
+  // Symmetric case: cursor 1px above the anchor, dragged far horizontally.
+  drag(*canvas, anchor, canvas->widget_position_for_document_point(QPoint(300, 99)));
+  sel = canvas->selected_document_rect();
+  CHECK(sel.has_value());
+  CHECK(sel->width() >= 1);
+  CHECK(sel->height() >= 1);
+}
+
 void ui_selection_toolbar_modes_work() {
   patchy::ui::MainWindow window;
   show_window(window);
@@ -21098,6 +21251,9 @@ int main(int argc, char* argv[]) {
       {"ui_text_reedit_preserves_rich_text_spacing",
        ui_text_reedit_preserves_rich_text_spacing},
       {"ui_marquee_selection_modifiers_work", ui_marquee_selection_modifiers_work},
+      {"ui_marquee_click_outside_canvas_deselects", ui_marquee_click_outside_canvas_deselects},
+      {"ui_marquee_shift_drag_constrains_to_square", ui_marquee_shift_drag_constrains_to_square},
+      {"ui_marquee_drag_keeps_minimum_one_pixel", ui_marquee_drag_keeps_minimum_one_pixel},
       {"ui_selection_toolbar_modes_work", ui_selection_toolbar_modes_work},
       {"ui_ctrl_a_selects_entire_canvas", ui_ctrl_a_selects_entire_canvas},
       {"ui_alt_backspace_fills_selection_with_foreground", ui_alt_backspace_fills_selection_with_foreground},


### PR DESCRIPTION
Brings the rectangular/elliptical marquee in line with Photoshop.

## Behavior
- **Click to deselect** — a plain click (no drag) clears the selection in
  Replace mode, inside the canvas or in the surrounding grey area.
- **Grey-area selection** — a marquee drag can start outside the canvas; the
  selection is clamped to the canvas bounds.
- **Shift = 1:1 constraint** (square for the rect, circle for the ellipse):
  - No active selection: Shift constrains from the press.
  - Existing selection: Shift adds a free shape; release + re-press Shift
    mid-drag to constrain the added shape.
  - Shift toggled with a stationary cursor still updates live.
  - Sized to the smaller drag axis, exact dimensions.
  - A drag begun in the grey area anchors the square at the edge it enters.

## Bug fix
Dragging through the point exactly 1px before the anchor collapsed the marquee
to a zero-size region (`QRect::normalized()` quirk) and blanked the selection
mid-drag. The rect now keeps a 1px minimum per axis.

## Tests
New offscreen UI tests cover deselect, grey-area selection, the Shift
constraint (all modes), exact small-size squares, edge anchoring, and the 1px
floor. Full suites pass: core 164, UI 321.
