### PR TITLE
Improve marquee/lasso selection tools: undo/redo, modes, preview

### DIFF
--- a/src/ui/canvas_widget.cpp
+++ b/src/ui/canvas_widget.cpp
@@ -1555,7 +1555,11 @@ bool CanvasWidget::eventFilter(QObject* watched, QEvent* event) {
       const auto bit = key_event->key() == Qt::Key_Shift ? Qt::ShiftModifier : Qt::AltModifier;
       const auto modifiers = event->type() == QEvent::KeyPress ? (key_event->modifiers() | bit)
                                                                : (key_event->modifiers() & ~bit);
-      apply_selection_cursor_for_mode(selection_operation(modifiers));
+      const auto mode = selection_operation(modifiers);
+      apply_selection_cursor_for_mode(mode);
+      if (selection_mode_changed_callback_) {
+        selection_mode_changed_callback_(mode);
+      }
     }
   }
   return QWidget::eventFilter(watched, event);
@@ -1753,11 +1757,17 @@ void CanvasWidget::set_tool(CanvasTool tool) {
     clear_move_hover_outline();
   }
   tool_ = tool;
+  // Each selection tool keeps its own combine mode; surface this tool's stored
+  // mode so the cursor badge and Options bar follow when switching tools.
+  if (const auto index = selection_tool_index(tool_); index >= 0) {
+    selection_mode_ = selection_modes_per_tool_[static_cast<std::size_t>(index)];
+  }
   update_tool_cursor();
   if (tool_changed) {
     update_move_transform_controls_dirty(old_transform_controls_rect);
     update();
     notify_transform_controls_changed();
+    notify_selection_mode_changed();
   }
 }
 
@@ -2049,14 +2059,64 @@ int CanvasWidget::fill_softness() const noexcept {
   return fill_softness_;
 }
 
+int CanvasWidget::selection_tool_index(CanvasTool tool) noexcept {
+  switch (tool) {
+    case CanvasTool::Marquee:
+      return 0;
+    case CanvasTool::EllipticalMarquee:
+      return 1;
+    case CanvasTool::Lasso:
+      return 2;
+    case CanvasTool::MagicWand:
+      return 3;
+    default:
+      return -1;
+  }
+}
+
 void CanvasWidget::set_selection_mode(SelectionMode mode) noexcept {
   selection_mode_ = mode;
+  if (const auto index = selection_tool_index(tool_); index >= 0) {
+    selection_modes_per_tool_[static_cast<std::size_t>(index)] = mode;
+  }
   // Reflect the new combine mode in the cursor badge right away.
   update_tool_cursor();
+  notify_selection_mode_changed();
 }
 
 CanvasWidget::SelectionMode CanvasWidget::selection_mode() const noexcept {
   return selection_mode_;
+}
+
+CanvasWidget::SelectionMode CanvasWidget::effective_selection_mode() const noexcept {
+  return selection_operation(QApplication::keyboardModifiers());
+}
+
+CanvasWidget::SelectionMode CanvasWidget::selection_mode_for_tool(CanvasTool tool) const noexcept {
+  const auto index = selection_tool_index(tool);
+  return index >= 0 ? selection_modes_per_tool_[static_cast<std::size_t>(index)] : SelectionMode::Replace;
+}
+
+void CanvasWidget::set_selection_mode_for_tool(CanvasTool tool, SelectionMode mode) noexcept {
+  const auto index = selection_tool_index(tool);
+  if (index < 0) {
+    return;
+  }
+  selection_modes_per_tool_[static_cast<std::size_t>(index)] = mode;
+  if (tool_ == tool) {
+    selection_mode_ = mode;
+    update_tool_cursor();
+    notify_selection_mode_changed();
+  }
+}
+
+void CanvasWidget::notify_selection_mode_changed() {
+  // Reports the tool's stored combine mode (tool switch / explicit mode choice).
+  // The live Shift/Alt override is reported separately from the key event filter,
+  // so a stale global modifier state can never mask an explicit choice.
+  if (selection_mode_changed_callback_) {
+    selection_mode_changed_callback_(selection_mode_);
+  }
 }
 
 void CanvasWidget::set_marquee_style(MarqueeStyle style) noexcept {
@@ -3390,6 +3450,14 @@ void CanvasWidget::set_before_edit_callback(std::function<void(QString)> callbac
   before_edit_callback_ = std::move(callback);
 }
 
+void CanvasWidget::set_selection_history_callback(std::function<void(QString, SelectionSnapshot, bool)> callback) {
+  selection_history_callback_ = std::move(callback);
+}
+
+void CanvasWidget::set_selection_mode_changed_callback(std::function<void(SelectionMode)> callback) {
+  selection_mode_changed_callback_ = std::move(callback);
+}
+
 void CanvasWidget::set_color_picked_callback(std::function<void(QColor)> callback) {
   color_picked_callback_ = std::move(callback);
 }
@@ -4128,6 +4196,9 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     selection_shift_at_press_ = (event->modifiers() & Qt::ShiftModifier) != 0 && !selection_.isEmpty();
     selection_shift_released_since_press_ = false;
     selection_square_constrained_ = false;
+    // With no existing selection Alt does not subtract; instead it mirrors the
+    // marquee about the press point (Photoshop's draw-from-center).
+    marquee_from_center_ = (event->modifiers() & Qt::AltModifier) != 0 && selection_.isEmpty();
     selection_start_ = snapped_point;
     selection_current_ = snapped_point;
     selection_before_edit_ = selection_;
@@ -4135,7 +4206,13 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     selection_mask_before_edit_bounds_ = selection_mask_bounds_;
     selection_mask_before_edit_alpha_ = selection_mask_alpha_;
     selection_operation_ = selection_operation(event->modifiers());
-    combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+    // Replace shows the rectangle live as you drag; Add/Subtract/Intersect keep
+    // the existing selection visible and only draw the candidate outline,
+    // committing the combine on release (like the Lasso) so you can see what
+    // you are about to add/subtract/intersect.
+    if (selection_operation_ == SelectionMode::Replace) {
+      combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+    }
     emit_info_for_widget_position(event->pos());
     update();
     return;
@@ -4170,6 +4247,7 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     begin_processing_operation();
     magic_wand_select(document_point);
     end_processing_operation();
+    record_selection_history(tr("Magic Wand"), selection_snapshot_before_edit());
     selection_before_edit_ = QRegion();
     selection_display_region_before_edit_ = QRegion();
     selection_mask_before_edit_bounds_ = {};
@@ -4493,7 +4571,11 @@ void CanvasWidget::mouseMoveEvent(QMouseEvent* event) {
       update_selection_square_constraint(event->modifiers());
       selection_current_ = snapped_marquee_current_point(selection_start_, document_point);
     }
-    combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+    // Replace updates the live selection; the combine modes defer to release and
+    // only redraw the candidate outline (see draw_selection_overlay).
+    if (selection_operation_ == SelectionMode::Replace) {
+      combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+    }
     emit_info_for_widget_position(event->pos());
     update();
   } else if (lassoing_ && document_ != nullptr) {
@@ -4822,8 +4904,12 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
       // which deselects (matching the click-to-deselect behaviour elsewhere).
       restore_selection_before_edit();
       clear_selection();
+      record_selection_history(tr("Deselect"), selection_snapshot_before_edit());
     } else {
       apply_selection_move(document_point - selection_move_origin_document_);
+      // Coalesce with any preceding move/nudge so a run of repositions is one
+      // undo step that returns to the pre-move location.
+      record_selection_history(tr("Move Selection"), selection_snapshot_before_edit(), /*coalesce=*/true);
     }
     selection_before_edit_ = QRegion();
     selection_display_region_before_edit_ = QRegion();
@@ -4842,12 +4928,15 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
     const bool was_click = !spacebar_repositioning_drag_rect_ &&
                            marquee_style_ != MarqueeStyle::FixedSize &&
                            widget_delta.manhattanLength() < QApplication::startDragDistance();
+    const auto marquee_label =
+        tool_ == CanvasTool::EllipticalMarquee ? tr("Elliptical Marquee") : tr("Rectangular Marquee");
     if (was_click) {
       // A plain click (no drag) deselects in Replace mode; add/subtract are no-ops.
       restore_selection_before_edit();
       if (selection_operation_ == SelectionMode::Replace) {
         clear_selection();
       }
+      record_selection_history(tr("Deselect"), selection_snapshot_before_edit());
       selection_before_edit_ = QRegion();
       selection_display_region_before_edit_ = QRegion();
       selection_mask_before_edit_bounds_ = {};
@@ -4876,10 +4965,12 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
     } else {
       combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
     }
+    record_selection_history(marquee_label, selection_snapshot_before_edit());
     selection_before_edit_ = QRegion();
     selection_display_region_before_edit_ = QRegion();
     selection_mask_before_edit_bounds_ = {};
     selection_mask_before_edit_alpha_ = QImage();
+    marquee_from_center_ = false;
     emit_info_for_widget_position(event->pos());
     update();
     return;
@@ -4895,6 +4986,7 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
       if (selection_operation_ == SelectionMode::Replace) {
         clear_selection();
       }
+      record_selection_history(tr("Deselect"), selection_snapshot_before_edit());
       selection_before_edit_ = QRegion();
       selection_display_region_before_edit_ = QRegion();
       selection_mask_before_edit_bounds_ = {};
@@ -4923,11 +5015,13 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
         restore_selection_before_edit();
       }
     }
+    record_selection_history(tr("Lasso"), selection_snapshot_before_edit());
     selection_before_edit_ = QRegion();
     selection_display_region_before_edit_ = QRegion();
     selection_mask_before_edit_bounds_ = {};
     selection_mask_before_edit_alpha_ = QImage();
     lasso_points_.clear();
+    emit_info_for_widget_position(event->pos());
     update();
     return;
   }
@@ -5200,9 +5294,9 @@ void CanvasWidget::keyPressEvent(QKeyEvent* event) {
 
   // With a selection tool active and a live selection, arrow keys nudge the
   // selection outline (Shift = 10px); the Move tool still nudges layer pixels.
-  // Auto-repeat is allowed here so holding an arrow scrolls the selection along
-  // (unlike the layer nudge below, a selection move records no undo snapshot, so
-  // there is nothing to spam).
+  // Auto-repeat is allowed here so holding an arrow scrolls the selection along;
+  // the nudges coalesce into a single undo step (see nudge_selection), so
+  // auto-repeat does not spam the history.
   if (!selection_.isEmpty() && !moving_selection_ &&
       (tool_ == CanvasTool::Marquee || tool_ == CanvasTool::EllipticalMarquee ||
        tool_ == CanvasTool::Lasso || tool_ == CanvasTool::MagicWand) &&
@@ -6429,6 +6523,41 @@ void CanvasWidget::draw_selection_overlay(QPainter& painter) const {
     painter.drawPolyline(preview);
     painter.setPen(white);
     painter.drawPolyline(preview);
+  }
+
+  // Add/Subtract/Intersect defer the combine to release (like the Lasso), so the
+  // existing selection stays put mid-drag and the candidate shape is shown as its
+  // own marching-ants outline. (Replace shows it live as the selection edge.)
+  if (selecting_ && selection_operation_ != SelectionMode::Replace &&
+      (tool_ == CanvasTool::Marquee || tool_ == CanvasTool::EllipticalMarquee)) {
+    // Trace the candidate edge exactly where the committed selection will land:
+    // the right/bottom edges sit one document pixel past the inclusive rect, the
+    // same convention the marching-ants outline above uses. (Do not route through
+    // widget_rect_for_document_rect(QRect) — that inflates the rect by 2px for
+    // hover/hit outlines, which would leave the preview sitting proud of the
+    // real selection.)
+    const auto doc_rect = marquee_selection_rect(selection_start_, selection_current_);
+    const QRectF widget_rect(widget_position_f(QPointF(doc_rect.left(), doc_rect.top())),
+                             widget_position_f(QPointF(doc_rect.right() + 1, doc_rect.bottom() + 1)));
+    QPainterPath preview;
+    if (tool_ == CanvasTool::EllipticalMarquee) {
+      preview.addEllipse(widget_rect);
+    } else {
+      preview.addRect(widget_rect);
+    }
+    QPen black(QColor(18, 20, 24), 1.0);
+    black.setDashPattern({4.0, 4.0});
+    black.setDashOffset(selection_dash_offset_ + 4);
+    black.setCosmetic(true);
+    QPen white(QColor(248, 250, 253), 1.0);
+    white.setDashPattern({4.0, 4.0});
+    white.setDashOffset(selection_dash_offset_);
+    white.setCosmetic(true);
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(black);
+    painter.drawPath(preview);
+    painter.setPen(white);
+    painter.drawPath(preview);
   }
 }
 
@@ -9073,7 +9202,30 @@ void CanvasWidget::magic_wand_select(QPoint start) {
 
 QRect CanvasWidget::marquee_selection_rect(QPoint anchor, QPoint current) const {
   QRect rect;
-  if (marquee_style_ == MarqueeStyle::FixedSize) {
+  if (marquee_from_center_) {
+    // Draw-from-center (Alt with no existing selection): the press point is the
+    // center, so the rectangle grows symmetrically and is twice the drag extent.
+    if (marquee_style_ == MarqueeStyle::FixedSize) {
+      rect = QRect(anchor - QPoint(marquee_fixed_size_.width() / 2, marquee_fixed_size_.height() / 2),
+                   marquee_fixed_size_);
+    } else {
+      const auto delta = current - anchor;
+      auto half_w = std::abs(delta.x());
+      auto half_h = std::abs(delta.y());
+      if (marquee_style_ == MarqueeStyle::FixedRatio) {
+        const auto ratio = std::max(1.0, static_cast<double>(marquee_fixed_size_.width())) /
+                           std::max(1.0, static_cast<double>(marquee_fixed_size_.height()));
+        if (static_cast<double>(half_w) / std::max(1, half_h) > ratio) {
+          half_h = std::max(0, static_cast<int>(std::round(half_w / ratio)));
+        } else {
+          half_w = std::max(0, static_cast<int>(std::round(half_h * ratio)));
+        }
+      } else if (selection_square_constrained_) {
+        half_w = half_h = std::min(half_w, half_h);
+      }
+      rect = QRect(anchor.x() - half_w, anchor.y() - half_h, half_w * 2, half_h * 2);
+    }
+  } else if (marquee_style_ == MarqueeStyle::FixedSize) {
     rect = QRect(anchor, marquee_fixed_size_);
   } else if (marquee_style_ == MarqueeStyle::FixedRatio) {
     const auto ratio =
@@ -9172,6 +9324,13 @@ QImage CanvasWidget::lasso_selection_mask(const QPolygon& polygon, QRect& bounds
 }
 
 CanvasWidget::SelectionMode CanvasWidget::selection_operation(Qt::KeyboardModifiers modifiers) const noexcept {
+  // With nothing selected there is nothing to add to / subtract from, so Shift
+  // and Alt do not switch the combine mode (they act as geometry constraints
+  // instead: Shift = square, Alt = draw from center). The badge and Options-bar
+  // buttons therefore stay on the tool's own stored mode.
+  if (selection_.isEmpty()) {
+    return selection_mode_;
+  }
   const auto add = modifiers.testFlag(Qt::ShiftModifier);
   const auto subtract = modifiers.testFlag(Qt::AltModifier);
   if (add && subtract) {
@@ -9258,7 +9417,11 @@ void CanvasWidget::refresh_active_marquee_selection() {
   if (!selecting_ || spacebar_repositioning_drag_rect_) {
     return;
   }
-  combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+  // Only Replace touches the live selection mid-drag; the combine modes defer to
+  // release, so a square-constraint toggle just redraws the candidate outline.
+  if (selection_operation_ == SelectionMode::Replace) {
+    combine_selection_from_region(marquee_selection_region(selection_start_, selection_current_));
+  }
   emit_info_for_widget_position(last_mouse_position_);
   update();
 }
@@ -9289,6 +9452,7 @@ void CanvasWidget::nudge_selection(QPoint delta) {
   if (selection_.isEmpty()) {
     return;
   }
+  const auto before = capture_selection_snapshot();
   if (selection_mask_alpha_.isNull()) {
     set_selection_from_region(selection_.translated(delta));
   } else {
@@ -9297,6 +9461,9 @@ void CanvasWidget::nudge_selection(QPoint delta) {
   }
   emit_info_for_widget_position(last_mouse_position_);
   update();
+  // Coalesce consecutive nudges (incl. key auto-repeat) into one undo step that
+  // returns to the position before the run started.
+  record_selection_history(tr("Move Selection"), before, /*coalesce=*/true);
 }
 
 void CanvasWidget::restore_selection_before_edit() {
@@ -9308,6 +9475,52 @@ void CanvasWidget::restore_selection_before_edit() {
   selection_mask_bounds_ = selection_mask_before_edit_bounds_;
   selection_mask_alpha_ = selection_mask_before_edit_alpha_;
   refresh_info_display();
+}
+
+CanvasWidget::SelectionSnapshot CanvasWidget::capture_selection_snapshot() const {
+  return SelectionSnapshot{selection_, selection_display_region_, selection_mask_bounds_, selection_mask_alpha_};
+}
+
+void CanvasWidget::apply_selection_snapshot(const SelectionSnapshot& snapshot) {
+  selection_ = snapshot.selection;
+  selection_display_region_ = snapshot.display_region;
+  if (selection_display_region_.isEmpty() && !selection_.isEmpty()) {
+    selection_display_region_ = selection_;
+  }
+  selection_mask_bounds_ = snapshot.mask_bounds;
+  selection_mask_alpha_ = snapshot.mask_alpha;
+  refresh_info_display();
+  update();
+}
+
+CanvasWidget::SelectionSnapshot CanvasWidget::selection_snapshot_before_edit() const {
+  return SelectionSnapshot{selection_before_edit_, selection_display_region_before_edit_,
+                           selection_mask_before_edit_bounds_, selection_mask_before_edit_alpha_};
+}
+
+namespace {
+bool selection_snapshots_equal(const CanvasWidget::SelectionSnapshot& a,
+                               const CanvasWidget::SelectionSnapshot& b) {
+  // Compare the committed selection region and any soft-edge mask; the display
+  // region is derived from these, so it does not need its own comparison.
+  return a.selection == b.selection && a.mask_bounds == b.mask_bounds && a.mask_alpha == b.mask_alpha;
+}
+}  // namespace
+
+void CanvasWidget::record_selection_history(QString label, const SelectionSnapshot& before, bool coalesce) {
+  if (!selection_history_callback_) {
+    return;
+  }
+  if (selection_snapshots_equal(before, capture_selection_snapshot())) {
+    return;
+  }
+  selection_history_callback_(std::move(label), before, coalesce);
+}
+
+void CanvasWidget::run_selection_command(QString label, const std::function<void()>& command) {
+  const auto before = capture_selection_snapshot();
+  command();
+  record_selection_history(std::move(label), before);
 }
 
 void CanvasWidget::combine_selection_from_region(const QRegion& candidate) {

--- a/src/ui/canvas_widget.hpp
+++ b/src/ui/canvas_widget.hpp
@@ -19,6 +19,7 @@
 #include <QString>
 #include <QWidget>
 
+#include <array>
 #include <cstdint>
 #include <chrono>
 #include <functional>
@@ -99,6 +100,20 @@ public:
     FixedRatio,
     FixedSize
   };
+
+  // Full selection state, captured so selection edits (marquee/lasso/wand drags,
+  // Select All, Deselect, Invert, ...) can participate in the undo/redo history.
+  struct SelectionSnapshot {
+    QRegion selection;
+    QRegion display_region;
+    QRect mask_bounds;
+    QImage mask_alpha;
+  };
+
+  // Tools whose combine mode (New/Add/Subtract/Intersect) is tracked separately,
+  // so switching between e.g. Lasso and Marquee preserves each tool's own mode.
+  static constexpr std::size_t kSelectionToolCount = 4;
+  [[nodiscard]] static int selection_tool_index(CanvasTool tool) noexcept;
 
   enum class LayerEditTarget {
     Content,
@@ -256,6 +271,17 @@ public:
   [[nodiscard]] int fill_softness() const noexcept;
   void set_selection_mode(SelectionMode mode) noexcept;
   [[nodiscard]] SelectionMode selection_mode() const noexcept;
+  // Combine mode actually in effect right now, folding in any held Shift/Alt and
+  // the "no override without an existing selection" rule (used by the cursor
+  // badge and the Options-bar mode buttons).
+  [[nodiscard]] SelectionMode effective_selection_mode() const noexcept;
+  [[nodiscard]] SelectionMode selection_mode_for_tool(CanvasTool tool) const noexcept;
+  void set_selection_mode_for_tool(CanvasTool tool, SelectionMode mode) noexcept;
+  [[nodiscard]] SelectionSnapshot capture_selection_snapshot() const;
+  void apply_selection_snapshot(const SelectionSnapshot& snapshot);
+  // Run a selection-changing command (Select All, Deselect, Invert, ...) and push
+  // an undo entry for it if the selection actually changed.
+  void run_selection_command(QString label, const std::function<void()>& command);
   void set_marquee_style(MarqueeStyle style) noexcept;
   [[nodiscard]] MarqueeStyle marquee_style() const noexcept;
   void set_marquee_fixed_size(int width, int height) noexcept;
@@ -347,6 +373,15 @@ public:
   [[nodiscard]] bool selection_contains(QPoint point) const noexcept;
   [[nodiscard]] QPoint widget_position_for_document_point(QPoint document_position) const;
   void set_before_edit_callback(std::function<void(QString)> callback);
+  // Invoked when a selection-only edit completes and actually changed the
+  // selection, so the host can push an undo entry holding the pre-edit state.
+  // `coalesce` marks a continuation of a move sequence (drag/nudge): consecutive
+  // coalescing edits collapse into the single entry holding the pre-sequence
+  // state, so a run of moves is one undo step.
+  void set_selection_history_callback(std::function<void(QString, SelectionSnapshot, bool coalesce)> callback);
+  // Invoked when the effective combine mode changes (tool switch, mode button,
+  // or live Shift/Alt) so the Options-bar mode buttons can follow.
+  void set_selection_mode_changed_callback(std::function<void(SelectionMode)> callback);
   void set_color_picked_callback(std::function<void(QColor)> callback);
   // Invoked when the canvas itself changes brush/gradient parameters (size
   // drag gesture, opacity digit keys) so the options bar can resync.
@@ -559,6 +594,11 @@ private:
   void set_selection_from_region(QRegion selection);
   void set_selection_from_mask(QRegion selection, QRect mask_bounds, QImage mask_alpha);
   void restore_selection_before_edit();
+  // Push an undo entry for a selection change whose pre-edit state is `before`,
+  // unless the selection is unchanged.
+  void record_selection_history(QString label, const SelectionSnapshot& before, bool coalesce = false);
+  [[nodiscard]] SelectionSnapshot selection_snapshot_before_edit() const;
+  void notify_selection_mode_changed();
   void update_selection_square_constraint(Qt::KeyboardModifiers modifiers);
   void refresh_active_marquee_selection();
   [[nodiscard]] bool can_move_selection_at(QPoint document_point, Qt::KeyboardModifiers modifiers) const;
@@ -680,6 +720,13 @@ private:
   int fill_softness_{0};
   bool auto_select_layer_{true};
   SelectionMode selection_mode_{SelectionMode::Replace};
+  // Per-tool combine modes; selection_mode_ mirrors the active selection tool's
+  // entry. Indexed by selection_tool_index().
+  std::array<SelectionMode, kSelectionToolCount> selection_modes_per_tool_{
+      SelectionMode::Replace, SelectionMode::Replace, SelectionMode::Replace, SelectionMode::Replace};
+  // Set when a marquee drag begins with Alt held and no existing selection: the
+  // press point is the center and the rectangle grows symmetrically.
+  bool marquee_from_center_{false};
   MarqueeStyle marquee_style_{MarqueeStyle::Normal};
   QSize marquee_fixed_size_{1024, 768};
   int selection_feather_radius_{0};
@@ -812,6 +859,8 @@ private:
   bool transform_requires_composited_preview_{false};
   std::optional<LayerId> move_transform_controls_layer_id_{};
   std::function<void(QString)> before_edit_callback_;
+  std::function<void(QString, SelectionSnapshot, bool)> selection_history_callback_;
+  std::function<void(SelectionMode)> selection_mode_changed_callback_;
   std::function<void(QColor)> color_picked_callback_;
   std::function<void()> brush_settings_changed_callback_;
   std::function<void(PenButtonAction)> pen_button_action_callback_;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -4211,6 +4211,11 @@ QString photoshop_style() {
       min-width: 26px;
       min-height: 26px;
     }
+    QToolButton[optionsBarButton="true"] {
+      padding: 2px;
+      min-width: 18px;
+      min-height: 16px;
+    }
     QToolButton:hover {
       background: #4a4a4a;
       border-color: #696969;
@@ -10004,16 +10009,26 @@ void MainWindow::create_actions() {
   register_hotkey(border_selection_action, "select.border");
   register_hotkey(layer_transparency_action, "select.layer_transparency");
   register_hotkey(stroke_selection_action, "edit.stroke_selection");
-  connect(select_all_action, &QAction::triggered, this, [this] { canvas_->select_all(); });
-  connect(clear_selection_action, &QAction::triggered, this, [this] { canvas_->clear_selection(); });
-  connect(reselect_action, &QAction::triggered, this, [this] { canvas_->reselect(); });
-  connect(inverse_selection_action, &QAction::triggered, this, [this] { canvas_->invert_selection(); });
-  connect(grow_selection_action, &QAction::triggered, this, [this] { canvas_->grow_selection(); });
-  connect(similar_selection_action, &QAction::triggered, this, [this] { canvas_->select_similar_to_selection(); });
+  connect(select_all_action, &QAction::triggered, this,
+          [this] { canvas_->run_selection_command(tr("Select All"), [this] { canvas_->select_all(); }); });
+  connect(clear_selection_action, &QAction::triggered, this,
+          [this] { canvas_->run_selection_command(tr("Deselect"), [this] { canvas_->clear_selection(); }); });
+  connect(reselect_action, &QAction::triggered, this,
+          [this] { canvas_->run_selection_command(tr("Reselect"), [this] { canvas_->reselect(); }); });
+  connect(inverse_selection_action, &QAction::triggered, this,
+          [this] { canvas_->run_selection_command(tr("Inverse Selection"), [this] { canvas_->invert_selection(); }); });
+  connect(grow_selection_action, &QAction::triggered, this,
+          [this] { canvas_->run_selection_command(tr("Grow Selection"), [this] { canvas_->grow_selection(); }); });
+  connect(similar_selection_action, &QAction::triggered, this, [this] {
+    canvas_->run_selection_command(tr("Select Similar"), [this] { canvas_->select_similar_to_selection(); });
+  });
   connect(expand_selection_action, &QAction::triggered, this, [this] { expand_selection_dialog(); });
   connect(contract_selection_action, &QAction::triggered, this, [this] { contract_selection_dialog(); });
   connect(border_selection_action, &QAction::triggered, this, [this] { border_selection_dialog(); });
-  connect(layer_transparency_action, &QAction::triggered, this, [this] { canvas_->select_active_layer_opaque_pixels(); });
+  connect(layer_transparency_action, &QAction::triggered, this, [this] {
+    canvas_->run_selection_command(tr("Load Layer Transparency"),
+                                   [this] { canvas_->select_active_layer_opaque_pixels(); });
+  });
   connect(stroke_selection_action, &QAction::triggered, this, [this] { stroke_selection(); });
   for (auto* action : {select_all_action, clear_selection_action, reselect_action, inverse_selection_action,
                        grow_selection_action, similar_selection_action, expand_selection_action,
@@ -10812,6 +10827,11 @@ void MainWindow::create_actions() {
     button->setToolButtonStyle(Qt::ToolButtonIconOnly);
     button->setIconSize(QSize(18, 18));
     button->setAutoRaise(true);
+    // Tagged for the compact Options-bar button style (see the app stylesheet).
+    // The default QToolButton min-height + padding makes it the tallest item in
+    // the row, which grows the whole Options toolbar when a selection tool is
+    // active. The icon keeps its full size; only the padding around it shrinks.
+    button->setProperty("optionsBarButton", true);
     options_flow->addWidget(button);
     register_option_action(button, tools);
     return action;
@@ -11057,7 +11077,11 @@ void MainWindow::create_actions() {
   configure_selection_mode_action(selection_intersect);
   selection_new->setChecked(true);
   const auto set_selection_mode = [this](CanvasWidget::SelectionMode mode) {
-    current_selection_mode_ = mode;
+    // Each selection tool keeps its own combine mode; store it for the active
+    // tool (so new documents inherit it) and apply it to the live canvas.
+    if (const auto index = CanvasWidget::selection_tool_index(current_tool_); index >= 0) {
+      selection_modes_[static_cast<std::size_t>(index)] = mode;
+    }
     if (canvas_ != nullptr) {
       canvas_->set_selection_mode(mode);
     }
@@ -12170,6 +12194,15 @@ void MainWindow::configure_canvas(CanvasWidget* canvas) {
   apply_canvas_aid_settings(canvas);
   apply_pen_input_settings(canvas);
   canvas->set_before_edit_callback([this](QString label) { push_undo_snapshot(std::move(label)); });
+  canvas->set_selection_history_callback(
+      [this](QString label, CanvasWidget::SelectionSnapshot before, bool coalesce) {
+        push_selection_history(std::move(label), std::move(before), coalesce);
+      });
+  canvas->set_selection_mode_changed_callback([this, canvas](CanvasWidget::SelectionMode mode) {
+    if (canvas == canvas_) {
+      update_selection_mode_buttons(mode);
+    }
+  });
   canvas->set_color_picked_callback([this, canvas](QColor color) {
     canvas->set_primary_color(color);
     refresh_color_buttons();
@@ -12325,8 +12358,8 @@ void MainWindow::add_document_session(Document document, QString title, QString 
   if (clone_aligned_check_ != nullptr) {
     session->canvas->set_clone_aligned(clone_aligned_check_->isChecked());
   }
+  apply_selection_modes_to_canvas(session->canvas);
   session->canvas->set_tool(current_tool_);
-  session->canvas->set_selection_mode(current_selection_mode_);
   session->canvas->set_marquee_style(current_marquee_style_);
   session->canvas->set_marquee_fixed_size(current_marquee_width_, current_marquee_height_);
   session->canvas->set_selection_feather_radius(current_selection_feather_radius_);
@@ -12391,8 +12424,8 @@ void MainWindow::activate_document_tab(int index) {
   }
   canvas_ = canvas;
   pending_layer_thumbnail_refresh_ = false;
+  apply_selection_modes_to_canvas(canvas_);
   canvas_->set_tool(current_tool_);
-  canvas_->set_selection_mode(current_selection_mode_);
   canvas_->set_marquee_style(current_marquee_style_);
   canvas_->set_marquee_fixed_size(current_marquee_width_, current_marquee_height_);
   canvas_->set_selection_feather_radius(current_selection_feather_radius_);
@@ -17775,7 +17808,7 @@ void MainWindow::expand_selection_dialog() {
   const auto pixels = request_integer_input(this, QStringLiteral("patchyExpandSelectionDialog"),
                                             tr("Expand Selection"), tr("Expand by"), 4, 1, 250, 1);
   if (pixels.has_value()) {
-    canvas_->expand_selection(*pixels);
+    canvas_->run_selection_command(tr("Expand Selection"), [this, pixels] { canvas_->expand_selection(*pixels); });
   }
 }
 
@@ -17787,7 +17820,7 @@ void MainWindow::contract_selection_dialog() {
   const auto pixels = request_integer_input(this, QStringLiteral("patchyContractSelectionDialog"),
                                             tr("Contract Selection"), tr("Contract by"), 4, 1, 250, 1);
   if (pixels.has_value()) {
-    canvas_->contract_selection(*pixels);
+    canvas_->run_selection_command(tr("Contract Selection"), [this, pixels] { canvas_->contract_selection(*pixels); });
   }
 }
 
@@ -17799,7 +17832,7 @@ void MainWindow::border_selection_dialog() {
   const auto pixels = request_integer_input(this, QStringLiteral("patchyBorderSelectionDialog"),
                                             tr("Border Selection"), tr("Width"), 4, 1, 250, 1);
   if (pixels.has_value()) {
-    canvas_->border_selection(*pixels);
+    canvas_->run_selection_command(tr("Border Selection"), [this, pixels] { canvas_->border_selection(*pixels); });
   }
 }
 
@@ -18217,11 +18250,15 @@ void MainWindow::undo() {
   if (active_session.undo_stack.empty()) {
     return;
   }
-  active_session.redo_stack.push_back(DocumentSession::HistoryState{active_session.document, active_session.revision});
+  active_session.redo_stack.push_back(DocumentSession::HistoryState{
+      active_session.document, active_session.revision, canvas_->capture_selection_snapshot()});
   active_session.document = active_session.undo_stack.back().document;
   active_session.revision = active_session.undo_stack.back().revision;
+  auto restored_selection = active_session.undo_stack.back().selection;
   active_session.undo_stack.pop_back();
+  active_session.selection_move_coalescing = false;
   canvas_->set_document(&active_session.document);
+  canvas_->apply_selection_snapshot(restored_selection);
   refresh_layer_list();
   refresh_layer_controls();
   canvas_->document_changed();
@@ -18237,11 +18274,15 @@ void MainWindow::redo() {
   if (active_session.redo_stack.empty()) {
     return;
   }
-  active_session.undo_stack.push_back(DocumentSession::HistoryState{active_session.document, active_session.revision});
+  active_session.undo_stack.push_back(DocumentSession::HistoryState{
+      active_session.document, active_session.revision, canvas_->capture_selection_snapshot()});
   active_session.document = active_session.redo_stack.back().document;
   active_session.revision = active_session.redo_stack.back().revision;
+  auto restored_selection = active_session.redo_stack.back().selection;
   active_session.redo_stack.pop_back();
+  active_session.selection_move_coalescing = false;
   canvas_->set_document(&active_session.document);
+  canvas_->apply_selection_snapshot(restored_selection);
   refresh_layer_list();
   refresh_layer_controls();
   canvas_->document_changed();
@@ -18270,17 +18311,52 @@ void MainWindow::push_undo_snapshot(QString label) {
   } else {
     snapshot_future.wait();
   }
-  active_session.undo_stack.push_back(DocumentSession::HistoryState{snapshot_future.get(), snapshot_revision});
+  // Capture the selection that is active right now (before the edit mutates the
+  // document) so undoing this edit also restores the selection it ran against.
+  auto snapshot_selection =
+      canvas_ != nullptr ? canvas_->capture_selection_snapshot() : CanvasWidget::SelectionSnapshot{};
+  active_session.undo_stack.push_back(
+      DocumentSession::HistoryState{snapshot_future.get(), snapshot_revision, std::move(snapshot_selection)});
   if (active_session.undo_stack.size() > kMaxUndo) {
     active_session.undo_stack.erase(active_session.undo_stack.begin());
   }
   active_session.redo_stack.clear();
+  active_session.selection_move_coalescing = false;
   mark_session_modified(active_session);
   update_history(label);
   update_undo_redo_actions();
   statusBar()->showMessage(label);
   const auto elapsed = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started).count();
   log_ui_profile("push_undo_snapshot", elapsed, label.toStdString());
+}
+
+void MainWindow::push_selection_history(QString label, CanvasWidget::SelectionSnapshot before, bool coalesce) {
+  finish_pending_layer_opacity_edit();
+  constexpr std::size_t kMaxUndo = 40;
+  auto& active_session = session();
+  // A run of moves/nudges collapses into one undo step: once the first move has
+  // pushed an entry holding the pre-run position, later moves leave the live
+  // selection updated but add no new entry, so undo returns to where the run
+  // began and redo lands on the final position. Any non-coalescing edit (below,
+  // or push_undo_snapshot) clears the flag and ends the run.
+  if (coalesce && active_session.selection_move_coalescing && !active_session.undo_stack.empty()) {
+    statusBar()->showMessage(label);
+    return;
+  }
+  // A selection-only edit leaves the pixels untouched, so the entry holds the
+  // current document together with the pre-edit selection. The document is not
+  // flagged modified for save purposes (a mere selection is not unsaved work),
+  // but the change still joins the undo/redo history.
+  active_session.undo_stack.push_back(
+      DocumentSession::HistoryState{active_session.document, active_session.revision, std::move(before)});
+  if (active_session.undo_stack.size() > kMaxUndo) {
+    active_session.undo_stack.erase(active_session.undo_stack.begin());
+  }
+  active_session.redo_stack.clear();
+  active_session.selection_move_coalescing = coalesce;
+  update_history(label);
+  update_undo_redo_actions();
+  statusBar()->showMessage(label);
 }
 
 void MainWindow::refresh_layer_list() {
@@ -20491,9 +20567,16 @@ void MainWindow::refresh_options_bar() {
     wand_sample_all_layers_check_->setChecked(canvas_->wand_sample_all_layers());
   }
   refresh_gradient_controls_from_canvas();
-  if (canvas_ != nullptr) {
-    current_selection_mode_ = canvas_->selection_mode();
-  }
+  // Show the active tool's stored combine mode. The temporary Shift/Alt override
+  // is applied live from the canvas's key event filter (see
+  // set_selection_mode_changed_callback), so it is not folded in here where a
+  // stale global modifier state could mask an explicit choice.
+  update_selection_mode_buttons(canvas_ != nullptr ? canvas_->selection_mode()
+                                                   : CanvasWidget::SelectionMode::Replace);
+  sync_text_alignment_buttons_from_editor();
+}
+
+void MainWindow::update_selection_mode_buttons(CanvasWidget::SelectionMode mode) {
   const auto set_checked = [](QAction* action, bool checked) {
     if (action == nullptr) {
       return;
@@ -20501,11 +20584,23 @@ void MainWindow::refresh_options_bar() {
     QSignalBlocker blocker(action);
     action->setChecked(checked);
   };
-  set_checked(selection_new_mode_action_, current_selection_mode_ == CanvasWidget::SelectionMode::Replace);
-  set_checked(selection_add_mode_action_, current_selection_mode_ == CanvasWidget::SelectionMode::Add);
-  set_checked(selection_subtract_mode_action_, current_selection_mode_ == CanvasWidget::SelectionMode::Subtract);
-  set_checked(selection_intersect_mode_action_, current_selection_mode_ == CanvasWidget::SelectionMode::Intersect);
-  sync_text_alignment_buttons_from_editor();
+  set_checked(selection_new_mode_action_, mode == CanvasWidget::SelectionMode::Replace);
+  set_checked(selection_add_mode_action_, mode == CanvasWidget::SelectionMode::Add);
+  set_checked(selection_subtract_mode_action_, mode == CanvasWidget::SelectionMode::Subtract);
+  set_checked(selection_intersect_mode_action_, mode == CanvasWidget::SelectionMode::Intersect);
+}
+
+void MainWindow::apply_selection_modes_to_canvas(CanvasWidget* canvas) {
+  if (canvas == nullptr) {
+    return;
+  }
+  const std::array<CanvasTool, CanvasWidget::kSelectionToolCount> tools{
+      CanvasTool::Marquee, CanvasTool::EllipticalMarquee, CanvasTool::Lasso, CanvasTool::MagicWand};
+  for (const auto tool : tools) {
+    if (const auto index = CanvasWidget::selection_tool_index(tool); index >= 0) {
+      canvas->set_selection_mode_for_tool(tool, selection_modes_[static_cast<std::size_t>(index)]);
+    }
+  }
 }
 
 MainWindow::PreviewDialogEditLock::PreviewDialogEditLock(MainWindow& window) noexcept : window_(&window) {

--- a/src/ui/main_window.hpp
+++ b/src/ui/main_window.hpp
@@ -20,6 +20,7 @@
 #include <QRect>
 #include <QString>
 #include <QStringList>
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
@@ -88,6 +89,9 @@ private:
     struct HistoryState {
       Document document;
       std::int64_t revision{0};
+      // Selection state at this point in history, so undo/redo restores the
+      // selection alongside the pixels (and selection-only edits are undoable).
+      CanvasWidget::SelectionSnapshot selection;
     };
 
     Document document;
@@ -102,6 +106,9 @@ private:
     std::set<LayerId> collapsed_layer_groups;
     std::int64_t revision{0};
     std::int64_t saved_revision{0};
+    // True when the top undo entry is a coalescable selection move, so the next
+    // move in the run merges into it instead of pushing a new entry.
+    bool selection_move_coalescing{false};
   };
 
   struct ClipboardPayload {
@@ -324,6 +331,16 @@ private:
   void undo();
   void redo();
   void push_undo_snapshot(QString label);
+  // Push an undo entry for a selection-only edit, holding the pre-edit selection
+  // `before` against the current (unchanged) document. When `coalesce` is true
+  // and the previous entry was also a coalescing move, the new state merges into
+  // it (a run of moves/nudges is a single undo step).
+  void push_selection_history(QString label, CanvasWidget::SelectionSnapshot before, bool coalesce = false);
+  // Mirror the given effective combine mode onto the Options-bar mode buttons
+  // (used for both committed modes and the live Shift/Alt override).
+  void update_selection_mode_buttons(CanvasWidget::SelectionMode mode);
+  // Apply the stored per-tool combine modes to a (new) canvas.
+  void apply_selection_modes_to_canvas(CanvasWidget* canvas);
   void refresh_layer_list();
   void refresh_layer_thumbnails();
   void refresh_layer_controls();
@@ -534,7 +551,11 @@ private:
   BrushToolSettings stored_paint_brush_settings_{};
   BrushToolSettings stored_eraser_brush_settings_{};
   bool eraser_brush_settings_active_{false};
-  CanvasWidget::SelectionMode current_selection_mode_{CanvasWidget::SelectionMode::Replace};
+  // Combine mode per selection tool (indexed by CanvasWidget::selection_tool_index),
+  // persisted across documents; each selection tool keeps its own mode.
+  std::array<CanvasWidget::SelectionMode, CanvasWidget::kSelectionToolCount> selection_modes_{
+      CanvasWidget::SelectionMode::Replace, CanvasWidget::SelectionMode::Replace,
+      CanvasWidget::SelectionMode::Replace, CanvasWidget::SelectionMode::Replace};
   CanvasWidget::MarqueeStyle current_marquee_style_{CanvasWidget::MarqueeStyle::Normal};
   int current_marquee_width_{1024};
   int current_marquee_height_{768};

--- a/tests/ui_visual_tests.cpp
+++ b/tests/ui_visual_tests.cpp
@@ -12101,6 +12101,50 @@ void ui_selection_arrow_keys_nudge() {
   CHECK(sel_after->top() == sel_before->top());
 }
 
+void ui_selection_moves_coalesce_into_one_undo_step() {
+  patchy::ui::MainWindow window;
+  show_window(window);
+  auto* canvas = require_canvas(window);
+  auto* undo_action = require_action_by_text(window, QStringLiteral("Undo"));
+  auto* redo_action = require_action_by_text(window, QStringLiteral("Redo"));
+  canvas->set_tool(patchy::ui::CanvasTool::Marquee);
+
+  drag(*canvas, canvas->widget_position_for_document_point(QPoint(50, 50)),
+       canvas->widget_position_for_document_point(QPoint(120, 110)));
+  CHECK(canvas->has_selection());
+  const auto origin = canvas->selected_document_rect()->topLeft();
+
+  // A run of nudges (including key auto-repeat) moves the selection but collapses
+  // into a single undo step.
+  send_key(*canvas, Qt::Key_Right);
+  send_key(*canvas, Qt::Key_Right);
+  send_key(*canvas, Qt::Key_Down);
+  for (int i = 0; i < 3; ++i) {
+    QKeyEvent autorep(QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier, QString(), true);
+    QApplication::sendEvent(canvas, &autorep);
+    QApplication::processEvents();
+  }
+  CHECK(canvas->selected_document_rect()->topLeft() == origin + QPoint(5, 1));
+
+  // One undo returns to the pre-move position (not just one nudge back); one redo
+  // restores the final moved position.
+  undo_action->trigger();
+  QApplication::processEvents();
+  CHECK(canvas->selected_document_rect()->topLeft() == origin);
+  redo_action->trigger();
+  QApplication::processEvents();
+  CHECK(canvas->selected_document_rect()->topLeft() == origin + QPoint(5, 1));
+
+  // The whole run is one entry sitting on top of the marquee: undoing twice
+  // removes the move, then the selection itself.
+  undo_action->trigger();
+  QApplication::processEvents();
+  CHECK(canvas->selected_document_rect()->topLeft() == origin);
+  undo_action->trigger();
+  QApplication::processEvents();
+  CHECK(!canvas->has_selection());
+}
+
 void ui_selection_cursor_shows_combine_mode_badge() {
   patchy::ui::MainWindow window;
   show_window(window);
@@ -12129,10 +12173,22 @@ void ui_selection_cursor_shows_combine_mode_badge() {
   canvas->set_selection_mode(patchy::ui::CanvasWidget::SelectionMode::Replace);
   CHECK(canvas->cursor().pixmap().toImage() == replace_image);
 
-  // Modifier changes update the badge even when the canvas does not hold focus
-  // and the pointer is stationary: the app-level event filter catches a Shift
-  // press delivered to the window. (The press event reports no modifier yet, so
-  // the cursor logic folds the pressed key in.)
+  // With no active selection there is nothing to add to / subtract from, so
+  // Shift and Alt do NOT switch the combine mode (they act as geometry
+  // constraints instead). The badge therefore stays on the tool's own mode.
+  send_key_press(window, Qt::Key_Shift, Qt::NoModifier);
+  CHECK(canvas->cursor().pixmap().toImage() == replace_image);
+  send_key_release(window, Qt::Key_Shift, Qt::ShiftModifier);
+  send_key_press(window, Qt::Key_Alt, Qt::NoModifier);
+  CHECK(canvas->cursor().pixmap().toImage() == replace_image);
+  send_key_release(window, Qt::Key_Alt, Qt::AltModifier);
+
+  // Once there is a selection to combine with, the same modifiers badge the
+  // crosshair. The app-level event filter catches a Shift press delivered to the
+  // window even with the pointer stationary. (The press event reports no
+  // modifier yet, so the cursor logic folds the pressed key in.)
+  canvas->select_all();
+  QApplication::processEvents();
   send_key_press(window, Qt::Key_Shift, Qt::NoModifier);
   const auto add_image = canvas->cursor().pixmap().toImage();
   CHECK(add_image != replace_image);
@@ -21494,11 +21550,18 @@ void ui_magic_wand_sample_all_layers_clear_transparent_active_layer_is_noop() {
   CHECK(canvas->has_selection());
   CHECK(canvas->selected_document_region().contains(QPoint(8, 8)));
   CHECK(!canvas->selected_document_region().contains(QPoint(55, 44)));
+  // The wand selection itself is an undoable step.
+  CHECK(undo_action->isEnabled());
 
   require_action(window, "layerClearAction")->trigger();
   QApplication::processEvents();
 
   CHECK(window.statusBar()->currentMessage().contains(QStringLiteral("Nothing to clear")));
+  // The no-op clear added no history: undoing once reverts the wand selection
+  // and leaves the stack empty, and the pixels were never touched.
+  require_action_by_text(window, QStringLiteral("Undo"))->trigger();
+  QApplication::processEvents();
+  CHECK(!canvas->has_selection());
   CHECK(!undo_action->isEnabled());
   CHECK(color_close(canvas_pixel(*canvas, QPoint(55, 44)), QColor(35, 95, 220), 8));
 }
@@ -22246,6 +22309,7 @@ int main(int argc, char* argv[]) {
       {"ui_marquee_drag_moves_selection", ui_marquee_drag_moves_selection},
       {"ui_lasso_drag_moves_selection", ui_lasso_drag_moves_selection},
       {"ui_selection_arrow_keys_nudge", ui_selection_arrow_keys_nudge},
+      {"ui_selection_moves_coalesce_into_one_undo_step", ui_selection_moves_coalesce_into_one_undo_step},
       {"ui_selection_cursor_shows_combine_mode_badge", ui_selection_cursor_shows_combine_mode_badge},
       {"ui_copy_paste_and_transform_pasted_layer_work", ui_copy_paste_and_transform_pasted_layer_work},
       {"ui_external_clipboard_image_paste_creates_centered_layer",


### PR DESCRIPTION
Improves the marquee and lasso selection tools.

## Behavior
- **Selection undo/redo** — selection edits now join the undo/redo history: marquee/lasso/magic-wand gesture commits, the Select menu commands (Select All, Deselect, Reselect, Inverse, Grow, Similar, Expand, Contract, Border, Load Layer Transparency), and selection moves. Undo/redo restore the selection (region + soft-edge mask) alongside the document. Selection-only edits don't flag the document as unsaved.
- **Coalesced moves** — a run of selection moves/nudges (including arrow-key auto-repeat or several drags in a row) collapses into one undo step that returns to the position before the run started; redo lands on the final position.
- **Deferred combine preview** — in Add/Subtract/Intersect the marquee keeps the existing selection visible and draws the candidate shape as its own marching-ants outline, committing the combine on release (like the lasso). Replace stays live.
- **Per-tool combine modes** — Marquee, Elliptical Marquee, Lasso, and Magic Wand each remember their own New/Add/Subtract/Intersect mode.
- **Modifier handling** — held Shift/Alt reflect in the Options-bar mode buttons. With no current selection, Shift/Alt no longer switch the combine mode; instead they act as geometry constraints — Shift = square, Alt = draw-from-center marquee.
- **Toolbar sizing** — the Options-bar mode buttons are compacted (padding only; icon size unchanged) so picking a selection tool no longer grows the Options toolbar.

## Tests
A new offscreen UI test covers the coalesced selection move/undo (a run of nudges, including key auto-repeat, collapses into one undo step and redoes to the final position). Two existing tests were updated for the new behavior: the combine-mode cursor badge (modifiers no longer switch mode without an active selection) and the magic-wand no-op clear (the wand selection is now an undoable step). The selection, cursor, marquee, lasso, and magic-wand UI test groups pass.
