### PR TITLE
Add screen-drag eyedropper sampling

### DIFF
--- a/src/ui/canvas_widget.cpp
+++ b/src/ui/canvas_widget.cpp
@@ -16,6 +16,7 @@
 #include <QEventLoop>
 #include <QFocusEvent>
 #include <QFontMetrics>
+#include <QGuiApplication>
 #include <QInputDevice>
 #include <QKeyEvent>
 #include <QLinearGradient>
@@ -30,6 +31,7 @@
 #include <QPointer>
 #include <QRadialGradient>
 #include <QResizeEvent>
+#include <QScreen>
 #include <QTabletEvent>
 #include <QTimerEvent>
 #include <QTransform>
@@ -1523,6 +1525,28 @@ bool tool_supports_opacity_digit_keys(CanvasTool tool) noexcept {
     default:
       return false;
   }
+}
+
+std::optional<QColor> screen_color_at_global_position(QPoint global_position) {
+  QScreen* screen = QGuiApplication::screenAt(global_position);
+  if (screen == nullptr) {
+    screen = QGuiApplication::primaryScreen();
+  }
+  if (screen == nullptr) {
+    return std::nullopt;
+  }
+
+  const QPoint screen_position = global_position - screen->geometry().topLeft();
+  const QPixmap sample = screen->grabWindow(0, screen_position.x(), screen_position.y(), 1, 1);
+  if (sample.isNull()) {
+    return std::nullopt;
+  }
+
+  const auto image = sample.toImage();
+  if (!image.rect().contains(0, 0)) {
+    return std::nullopt;
+  }
+  return image.pixelColor(0, 0);
 }
 
 }  // namespace
@@ -3883,6 +3907,16 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
     }
     clear_guide_selection();
   }
+  const bool color_pick_press =
+      event->button() == Qt::LeftButton &&
+      (tool_ == CanvasTool::Eyedropper ||
+       ((event->modifiers() & Qt::AltModifier) != 0 && tool_uses_alt_left_for_color_pick(tool_)));
+  if (color_pick_press) {
+    begin_color_pick(event->pos(), event->globalPosition().toPoint());
+    event->accept();
+    return;
+  }
+
   if (!document_contains(document_point)) {
     // Marquee and lasso presses may begin in the grey area; let them through to
     // their selection handlers. Other tools discard an out-of-bounds press.
@@ -3907,12 +3941,6 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
         return;
       }
     }
-  }
-
-  if (event->button() == Qt::LeftButton && (event->modifiers() & Qt::AltModifier) != 0 &&
-      tool_uses_alt_left_for_color_pick(tool_)) {
-    pick_color(document_point);
-    return;
   }
 
   // Photoshop-style stroke connect: Shift+click joins the new stroke to the
@@ -3957,11 +3985,6 @@ void CanvasWidget::mousePressEvent(QMouseEvent* event) {
         document_changed_impl(QRegion(dirty), false, DocumentChangeReason::BrushStrokePreview);
       }
     }
-    return;
-  }
-
-  if (tool_ == CanvasTool::Eyedropper) {
-    pick_color(document_point);
     return;
   }
 
@@ -4300,6 +4323,16 @@ void CanvasWidget::mouseMoveEvent(QMouseEvent* event) {
       return;
     }
   }
+  if (color_picking_) {
+    if ((event->buttons() & Qt::LeftButton) != 0) {
+      update_color_pick(event->pos(), event->globalPosition().toPoint());
+    } else {
+      end_color_pick();
+    }
+    last_mouse_position_ = event->pos();
+    event->accept();
+    return;
+  }
   if (panning_) {
     clear_move_hover_outline();
     const auto delta = event->pos() - last_mouse_position_;
@@ -4549,7 +4582,7 @@ void CanvasWidget::refresh_tool_cursor() {
   // the pointer enters the canvas or the canvas/window regains focus, since a
   // pen does not emit move events on its own and Windows may reset the cursor
   // to an arrow when the window is re-activated.
-  if (!panning_ && !pen_zoom_dragging_ && !dragging_transform_ && !transforming_layer_) {
+  if (!panning_ && !pen_zoom_dragging_ && !dragging_transform_ && !transforming_layer_ && !color_picking_) {
     update_tool_cursor();
   }
 }
@@ -4600,6 +4633,14 @@ void CanvasWidget::mouseReleaseEvent(QMouseEvent* event) {
         end_zoom_drag();
       }
     }
+  }
+  if (color_picking_) {
+    if (event->button() == Qt::LeftButton || (event->buttons() & Qt::LeftButton) == 0) {
+      update_color_pick(event->pos(), event->globalPosition().toPoint());
+      end_color_pick();
+    }
+    event->accept();
+    return;
   }
   if (panning_) {
     panning_ = false;
@@ -5340,6 +5381,9 @@ void CanvasWidget::focusOutEvent(QFocusEvent* event) {
   const auto was_painting = painting_;
   if (brush_adjust_dragging_) {
     end_brush_adjust_drag(true);
+  }
+  if (color_picking_) {
+    end_color_pick();
   }
   spacebar_repositioning_drag_rect_ = false;
   spacebar_panning_ = false;
@@ -8909,16 +8953,52 @@ QRect CanvasWidget::flood_fill_mask(QPoint start) {
   return dirty;
 }
 
+void CanvasWidget::begin_color_pick(QPoint widget_position, QPoint global_position) {
+  color_picking_ = true;
+  grabMouse();
+  update_color_pick(widget_position, global_position);
+}
+
+void CanvasWidget::update_color_pick(QPoint widget_position, QPoint global_position) {
+  const auto point = document_position(widget_position);
+  if (document_contains(point)) {
+    pick_color(point);
+    return;
+  }
+
+  if (const auto picked = screen_color_at_global_position(global_position); picked.has_value()) {
+    set_picked_color(*picked);
+  }
+}
+
+void CanvasWidget::end_color_pick() {
+  if (!color_picking_) {
+    return;
+  }
+  color_picking_ = false;
+  if (QWidget::mouseGrabber() == this) {
+    releaseMouse();
+  }
+  update_tool_cursor();
+}
+
+void CanvasWidget::set_picked_color(QColor picked) {
+  if (!picked.isValid()) {
+    return;
+  }
+  picked.setAlpha(255);
+  primary_color_ = picked;
+  if (color_picked_callback_) {
+    color_picked_callback_(picked);
+  }
+}
+
 void CanvasWidget::pick_color(QPoint point) {
   if (document_ == nullptr || !document_contains(point)) {
     return;
   }
 
-  const auto picked = compose_document_pixel(point.x(), point.y());
-  primary_color_ = picked;
-  if (color_picked_callback_) {
-    color_picked_callback_(picked);
-  }
+  set_picked_color(compose_document_pixel(point.x(), point.y()));
 }
 
 void CanvasWidget::magic_wand_select(QPoint start) {

--- a/src/ui/canvas_widget.hpp
+++ b/src/ui/canvas_widget.hpp
@@ -550,6 +550,10 @@ private:
   [[nodiscard]] QRect draw_mask_ellipse(QPoint from, QPoint to, bool erase);
   [[nodiscard]] QRect render_mask_shape(QRect rect, bool erase, patchy::ShapeKind kind);
   [[nodiscard]] QRect flood_fill_mask(QPoint start);
+  void begin_color_pick(QPoint widget_position, QPoint global_position);
+  void update_color_pick(QPoint widget_position, QPoint global_position);
+  void end_color_pick();
+  void set_picked_color(QColor color);
   void pick_color(QPoint point);
   void magic_wand_select(QPoint start);
   [[nodiscard]] QRegion marquee_selection_region(QPoint anchor, QPoint current) const;
@@ -707,6 +711,7 @@ private:
   bool moving_layer_{false};
   bool transforming_layer_{false};
   bool dragging_transform_{false};
+  bool color_picking_{false};
   bool selecting_{false};
   bool lassoing_{false};
   bool moving_selection_{false};

--- a/tests/ui_visual_tests.cpp
+++ b/tests/ui_visual_tests.cpp
@@ -3496,6 +3496,32 @@ void ui_alt_left_click_samples_foreground_color() {
   CHECK(color_close(canvas_pixel(*canvas, sample_document_point), sampled_before_click, 0));
 }
 
+void ui_eyedropper_starts_in_gray_area_and_drags_to_document_color() {
+  patchy::ui::MainWindow window;
+  show_window(window);
+  auto* canvas = require_canvas(window);
+
+  require_action_by_text(window, QStringLiteral("Brush"))->trigger();
+  canvas->set_primary_color(QColor(34, 201, 145));
+  use_solid_fill_settings(canvas);
+  require_action(window, "layerFillForegroundAction")->trigger();
+  QApplication::processEvents();
+
+  const auto grey_start = canvas->widget_position_for_document_point(QPoint(-24, -24));
+  const QPoint sample_document_point(80, 80);
+  const auto sample_widget_point = canvas->widget_position_for_document_point(sample_document_point);
+  CHECK(canvas->rect().contains(grey_start));
+  CHECK(color_close(canvas_pixel(*canvas, sample_document_point), QColor(34, 201, 145), 4));
+
+  canvas->set_primary_color(QColor(230, 20, 20));
+  require_action_by_text(window, QStringLiteral("Pick"))->trigger();
+  send_mouse(*canvas, QEvent::MouseButtonPress, grey_start, Qt::LeftButton, Qt::LeftButton);
+  send_mouse(*canvas, QEvent::MouseMove, sample_widget_point, Qt::NoButton, Qt::LeftButton);
+  send_mouse(*canvas, QEvent::MouseButtonRelease, sample_widget_point, Qt::LeftButton, Qt::NoButton);
+
+  CHECK(color_close(canvas->primary_color(), QColor(34, 201, 145), 4));
+}
+
 void ui_photoshop_shortcuts_are_registered() {
   patchy::ui::MainWindow window;
   show_window(window);
@@ -22044,6 +22070,8 @@ int main(int argc, char* argv[]) {
       {"ui_psd_import_warning_dialog_shows_when_enabled",
        ui_psd_import_warning_dialog_shows_when_enabled},
       {"ui_alt_left_click_samples_foreground_color", ui_alt_left_click_samples_foreground_color},
+      {"ui_eyedropper_starts_in_gray_area_and_drags_to_document_color",
+       ui_eyedropper_starts_in_gray_area_and_drags_to_document_color},
       {"ui_photoshop_shortcuts_are_registered", ui_photoshop_shortcuts_are_registered},
       {"ui_hotkey_resolution_rules", ui_hotkey_resolution_rules},
       {"ui_hotkey_defaults_have_no_conflicts", ui_hotkey_defaults_have_no_conflicts},


### PR DESCRIPTION
Summary:
- Let the eyedropper and Alt-left temporary picker start a pick drag from the gray canvas workspace.
- Continue sampling while dragged outside the document, using screen pixels when the cursor is off-document.
- Add visual test coverage for gray-area eyedropper drag start.

Tests:
- Release preset build completed.
- patchy_core_tests.exe passed.
- QT_QPA_PLATFORM=offscreen patchy_ui_visual_tests.exe passed.