### PR TITLE
Toolbar slider fixes: drag lag and click-to-snap

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -16,6 +16,7 @@
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QPointer>
+#include <QProxyStyle>
 #include <QStringList>
 
 #include <algorithm>
@@ -94,6 +95,23 @@ bool forward_to_running_instance(const QStringList& files) {
   return true;
 }
 
+// Make a left-click anywhere on a slider's groove jump straight to that value
+// and begin dragging, instead of Qt's default page-step that crawls toward the
+// cursor in chunks. Wraps the platform style and overrides only this one hint,
+// so all other rendering (including the app stylesheet) is unchanged.
+class SliderClickToValueStyle : public QProxyStyle {
+ public:
+  using QProxyStyle::QProxyStyle;
+
+  int styleHint(StyleHint hint, const QStyleOption* option, const QWidget* widget,
+                QStyleHintReturn* return_data) const override {
+    if (hint == SH_Slider_AbsoluteSetButtons) {
+      return Qt::LeftButton;
+    }
+    return QProxyStyle::styleHint(hint, option, widget, return_data);
+  }
+};
+
 QFont application_font() {
   const QStringList font_files = {
       QStringLiteral("C:/Windows/Fonts/arial.ttf"),
@@ -138,6 +156,8 @@ QFont application_font() {
 int main(int argc, char* argv[]) {
   apply_gui_scale_factor();
   QApplication app(argc, argv);
+  // Slider grooves snap to the click and start dragging (see the style above).
+  app.setStyle(new SliderClickToValueStyle);
   app.setApplicationName(QStringLiteral("Patchy"));
   app.setApplicationVersion(QStringLiteral(PATCHY_VERSION));
   // Keep the internal app identity for settings without letting Qt append " - Patchy" to every native window title.

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -299,6 +299,10 @@ constexpr int kOpenProgressTitleMinimumFileNameWidth = 180;
 constexpr int kFilterProgressMinimumDurationMs = 1000;
 constexpr int kLayerOpacityApplyDelayMs = 33;
 constexpr int kLayerOpacityIdleFinishDelayMs = 250;
+// Tool-option sliders apply to the canvas live but persist to disk only this
+// long after the last change, so dragging a slider does not write the whole
+// settings file on every intermediate value.
+constexpr int kToolSettingsSaveDelayMs = 250;
 constexpr int kMaxRecentFiles = 200;
 constexpr int kMaxRecentFolders = 10;
 constexpr int kRecentFilesMenuPageSize = 50;
@@ -8410,6 +8414,10 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
   layer_opacity_idle_timer_->setSingleShot(true);
   layer_opacity_idle_timer_->setInterval(kLayerOpacityIdleFinishDelayMs);
   connect(layer_opacity_idle_timer_, &QTimer::timeout, this, [this] { finish_pending_layer_opacity_edit(); });
+  tool_settings_save_timer_ = new QTimer(this);
+  tool_settings_save_timer_->setSingleShot(true);
+  tool_settings_save_timer_->setInterval(kToolSettingsSaveDelayMs);
+  connect(tool_settings_save_timer_, &QTimer::timeout, this, [this] { save_tool_settings(); });
   load_pen_input_settings();
   reset_document(1024, 768, Qt::white, tr("New document"));
   load_tool_settings();
@@ -9528,6 +9536,9 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     }
   }
   save_window_geometry();
+  // Flush any tool-option change still waiting on the save debounce; the timer
+  // will not fire once the window is gone.
+  save_tool_settings();
   event->accept();
 }
 
@@ -11276,7 +11287,7 @@ void MainWindow::create_actions() {
   connect(brush_size, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_brush_size(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
       refresh_document_info();
     }
   });
@@ -11285,7 +11296,7 @@ void MainWindow::create_actions() {
   connect(brush_opacity, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_brush_opacity(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
       refresh_document_info();
     }
   });
@@ -11294,7 +11305,7 @@ void MainWindow::create_actions() {
   connect(brush_softness, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_brush_softness(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
       refresh_document_info();
     }
   });
@@ -11377,7 +11388,7 @@ void MainWindow::create_actions() {
     if (canvas_ != nullptr) {
       canvas_->set_gradient_opacity(value);
       refresh_gradient_controls_from_canvas();
-      save_tool_settings();
+      schedule_save_tool_settings();
       refresh_document_info();
     }
   });
@@ -11442,7 +11453,7 @@ void MainWindow::create_actions() {
   connect(wand_tolerance, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_wand_tolerance(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
       refresh_document_info();
     }
   });
@@ -11494,7 +11505,7 @@ void MainWindow::create_actions() {
   connect(shape_corner_radius, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_shape_corner_radius(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
     }
   });
 
@@ -11534,7 +11545,7 @@ void MainWindow::create_actions() {
   connect(fill_opacity, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_fill_opacity(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
     }
   });
   connect(fill_softness, &QSpinBox::valueChanged, fill_softness_slider, &QSlider::setValue);
@@ -11542,7 +11553,7 @@ void MainWindow::create_actions() {
   connect(fill_softness, &QSpinBox::valueChanged, this, [this](int value) {
     if (canvas_ != nullptr) {
       canvas_->set_fill_softness(value);
-      save_tool_settings();
+      schedule_save_tool_settings();
     }
   });
 
@@ -19424,9 +19435,22 @@ void MainWindow::load_tool_settings() {
   }
 }
 
+void MainWindow::schedule_save_tool_settings() {
+  if (tool_settings_save_timer_ != nullptr) {
+    tool_settings_save_timer_->start();
+  } else {
+    save_tool_settings();
+  }
+}
+
 void MainWindow::save_tool_settings() const {
   if (canvas_ == nullptr) {
     return;
+  }
+  // An explicit save captures the current state, so drop any debounced one
+  // still pending; otherwise it would fire later and rewrite the same values.
+  if (tool_settings_save_timer_ != nullptr) {
+    tool_settings_save_timer_->stop();
   }
   auto settings = app_settings();
   auto paint_brush_settings = stored_paint_brush_settings_;

--- a/src/ui/main_window.hpp
+++ b/src/ui/main_window.hpp
@@ -359,6 +359,9 @@ private:
   [[nodiscard]] QColor current_text_color() const;
   void load_tool_settings();
   void save_tool_settings() const;
+  // Restart the debounce so the live tool-option sliders flush to disk once,
+  // after the drag settles, instead of on every intermediate value.
+  void schedule_save_tool_settings();
   [[nodiscard]] BrushToolSettings& active_stored_brush_settings();
   void stash_active_brush_settings();
   void apply_active_brush_settings_to_canvas();
@@ -438,6 +441,7 @@ private:
   QSpinBox* opacity_spin_{nullptr};
   QTimer* layer_opacity_apply_timer_{nullptr};
   QTimer* layer_opacity_idle_timer_{nullptr};
+  QTimer* tool_settings_save_timer_{nullptr};
   QComboBox* blend_combo_{nullptr};
   QCheckBox* visible_check_{nullptr};
   QToolButton* lock_transparent_pixels_button_{nullptr};


### PR DESCRIPTION
Two small fixes for the Options-toolbar sliders:

- **Drag lag** — dragging a slider (brush size/opacity/softness, gradient/fill opacity, etc.) saved all tool settings to disk on every value it passed through, rewriting the settings file every tick. The write is now debounced to once after the drag settles; the canvas and status bar still update live.
- **Click-to-snap** — clicking a slider's groove paged toward the cursor in chunks. A small `QProxyStyle` makes a groove click jump straight to that value and continue into a drag, like most apps. Applies to every slider.
